### PR TITLE
Fix from transformers issue #12833

### DIFF
--- a/bloomex_nb.ipynb
+++ b/bloomex_nb.ipynb
@@ -30,8 +30,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tokenizer = BloomTokenizerFast.from_pretrained(\"bigscience/bloom-1b3\")\n",
-    "model = BloomForCausalLM.from_pretrained(\"bigscience/bloom-1b3\")"
+    "tokenizer = BloomTokenizerFast.from_pretrained(\"bigscience/bloom-1b3\", l
+ocal_files_only=True)\n",
+    "model = BloomForCausalLM.from_pretrained(\"bigscience/bloom-1b3\", l
+ocal_files_only=True)"
    ]
   },
   {


### PR DESCRIPTION
Ran into this error:
`OSError: Distant resource does not have an ETag, we won't be able to reliably ensure reproducibility.`

Looking around, this github issue address this issue:

https://github.com/huggingface/transformers/issues/12833

This PR applies this fix, the error went away.